### PR TITLE
Fix: Mobile sign-in modal & waitlist sidebar cleanup

### DIFF
--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -284,12 +284,7 @@ export default function WaitlistPage() {
                               Dashboard
                             </span>
                           </Link>
-                          <div className="flex items-center space-x-3 px-4 py-3 rounded-xl text-primary bg-primary/10 border border-primary/20 backdrop-blur-sm shadow-lg">
-                            <Users className="h-5 w-5 text-primary drop-shadow-sm" />
-                            <span className="font-semibold drop-shadow-sm">
-                              Waitlist
-                            </span>
-                          </div>
+                          {/* Removed redundant Waitlist item on Waitlist page */}
                         </div>
                       </nav>
 
@@ -528,12 +523,7 @@ export default function WaitlistPage() {
                             Contact
                           </span>
                         </Link>
-                        <div className="flex items-center space-x-3 px-4 py-3 rounded-xl text-primary bg-primary/10 border border-primary/20 backdrop-blur-sm shadow-lg">
-                          <Users className="h-5 w-5 text-primary drop-shadow-sm" />
-                          <span className="font-semibold drop-shadow-sm">
-                            Waitlist
-                          </span>
-                        </div>
+                        {/* Removed redundant Waitlist item on Waitlist page */}
                       </div>
                     </nav>
 

--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -259,7 +259,6 @@ export function Navigation() {
                             variant="outline"
                             size="sm"
                             className="w-full mb-2"
-                            onClick={() => setIsMenuOpen(false)}
                           >
                             <LogIn className="h-4 w-4 mr-2" />
               Sign in


### PR DESCRIPTION
This PR fixes two mobile UI issues:

1) Mobile sidebar Sign In not opening the modal
- Problem: The mobile Sign In button in the navigation sidebar closed the sheet in the same click as the dialog trigger, preventing the Radix Dialog from opening consistently on mobile.
- Fix: Removed the sheet-closing onClick handler from the Sign In button wrapped by <SignInModal> so the dialog can mount reliably. Sheet can remain open behind the modal; we can hook dialog open state to close the sheet later if preferred.
- File: src/components/ui/navigation.tsx

2) Redundant "Waitlist" entry on the Waitlist page’s side nav
- Problem: On /waitlist, the side nav still showed a “Waitlist” item that points to the page you’re already on, causing confusion.
- Fix: Removed the Waitlist entry from the mobile side nav both in the default view and the submitted state view.
- File: src/app/waitlist/page.tsx

Build status: `next build` successful locally.

Notes / follow-ups:
- If desired, we can auto-close the sheet when the dialog opens for a slightly cleaner experience. For now the modal opens reliably and the sheet remains in the background.

Thanks!